### PR TITLE
Add CIRCLE_BRANCH_NO_SLASHES to tag names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
       branch:
         type: string
         default: "main"
-    steps: 
+    steps:
       - when:
           condition: << pipeline.parameters.target_workflow >>
           steps:


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

Currently, any work done in branches in this repository will get pushed to the `main-alpine` and `main-rhel7` Docker tags. This commit adds the local branch name to prevent the latest `main-*` branches containing WIP changes. The latest tag names will change to `main-main-alpine` and `main-main-rhel7` as a result of this change.