### PR TITLE
Skip version check on linux/s390x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,10 +167,15 @@ commands:
                 file << parameters.binary >>
                 cat << parameters.binary >>
               fi
-      - run:
-          name: Verify version of << parameters.working_directory >>/<< parameters.binary >>
-          working_directory: << parameters.working_directory >>
-          command: ./<< parameters.binary >> version
+      - when:
+          condition:
+            not:
+              equal: ["<< parameters.working_directory >>", "target/linux/s390x"]
+          steps:
+            - run:
+                name: Verify version of << parameters.working_directory >>/<< parameters.binary >>
+                working_directory: << parameters.working_directory >>
+                command: ./<< parameters.binary >> version
   unsupported-binary:
     parameters:
       working_directory:


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

The version verification step in CircleCI results in a segmentation fault when trying to run binaries for `linux/s390x` with binaries produced with Go 1.15 & 1.16.

This will prevent the verification step from happening for `linux/s390x` binaries only. We can revert this change in the future if `multiarch/qemu-user-static` is ever updated with a newer version of qemu that supports newer Go-built binaries.