### PR TITLE
Upgrade machine executor & buildx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,7 +308,8 @@ workflows:
           tag: "$TARGET_BRANCH_NO_SLASHES-$CIRCLE_BRANCH_NO_SLASHES-alpine,$TARGET_REVISION-alpine"
           pre-steps:
             - checkout
-            - buildx/install
+            - buildx/install:
+                version: 0.5.1
             - create-target-directory
             - setenv-target-workflow
             - setup-metadata:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,7 +276,7 @@ jobs:
   build-docker:
     executor:
       name: docker/machine
-      image: "ubuntu-2004:202010-01"
+      image: "ubuntu-2004:202101-01"
       dlc: true
     parameters:
       platforms:


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

This seems to fix the `container is marked for removal and cannot be started` seen on CircleCI.