### PR TITLE
Fix syntax error on unsupported systems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ commands:
           working_directory: << parameters.working_directory >>
           command: >
             printf "#!/bin/sh\necho \"<< parameters.binary >> is not
-            available for this platform\nexit 1\"\"" > << parameters.binary >>
+            available for this platform\nexit 1\"" > << parameters.binary >>
       - run:
           name: Add execute bit to << parameters.working_directory >>/<< parameters.binary >>
           working_directory: << parameters.working_directory >>


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## Description

Fixes a syntax error in the scripts that replace binaries on unsupported platforms.

Closes #22.

## Before Fix
```sh
➜  sensu-docker (fix-syntax-err) ✔ docker run --rm -it --platform linux/arm/v6 sensu/sensu:latest sensu-backend start
Unable to find image 'sensu/sensu:latest' locally
latest: Pulling from sensu/sensu
66e54586dae0: Pull complete
902f2f46ee61: Pull complete
a8e3bc431585: Pull complete
8b09fe665bc3: Pull complete
a35e9c728c6c: Pull complete
4522f94d7abd: Pull complete
0e38813ebb5c: Pull complete
5d590c4a7b61: Pull complete
4059fe5579a8: Pull complete
8b6f0ecf07ec: Pull complete
b10ab030f0c1: Pull complete
50b72320399c: Pull complete
cab7d87d7a0f: Pull complete
7ae113ab6cf2: Pull complete
e9ee56a3a157: Pull complete
8b529a29edcb: Pull complete
be381565522a: Pull complete
b3c5e639cef7: Pull complete
fc25eb6f6da1: Pull complete
85bbfa15da57: Pull complete
Digest: sha256:3b428acff485248b57dc6974e5f80c7ef686a8d5a38e418e439b4d1a81e42993
Status: Downloaded newer image for sensu/sensu:latest
== waiting for 4edc3354be79:2379 to become available before running backend-init...
/opt/sensu/bin/sensu-backend: line 3: syntax error: unterminated quoted string
```


## After Fix
```sh
➜  sensu-docker (fix-syntax-err) ✔ docker run --rm -it --platform linux/arm/v6 sensu/sensu-ci:main-fix-syntax-err-alpine sensu-backend start
Unable to find image 'sensu/sensu-ci:main-fix-syntax-err-alpine' locally
main-fix-syntax-err-alpine: Pulling from sensu/sensu-ci
66e54586dae0: Already exists
4f29d0ab88c6: Pull complete
25724bacc56b: Pull complete
81e63888aeef: Pull complete
96b19697ee19: Pull complete
762123119e7c: Pull complete
ad8baa715fb9: Pull complete
6de655ace5da: Pull complete
4f67a8308754: Pull complete
ff12cb008957: Pull complete
1225a98c6ff9: Pull complete
c38d070bae59: Pull complete
ea8464ec2796: Pull complete
37951c3b512c: Pull complete
402fff617719: Pull complete
df0b3895124f: Pull complete
b8e682624faa: Pull complete
9d4fa2e7faad: Pull complete
ce9f9a806f55: Pull complete
dfb170be32d8: Pull complete
Digest: sha256:d08940ad1f3838e731f513d19ad164106105ccf495a78321c1e9443598e3aeb5
Status: Downloaded newer image for sensu/sensu-ci:main-fix-syntax-err-alpine
== waiting for 3cca7c4abdce:2379 to become available before running backend-init...
sensu-backend is not available for this platform
exit 1
```
