### PR TITLE
Add new tags for version & build num

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,7 +307,7 @@ workflows:
           name: build-alpine
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
           path: dockerfiles/alpine
-          tag: "$TARGET_BRANCH_NO_SLASHES-$CIRCLE_BRANCH_NO_SLASHES-alpine,$TARGET_REVISION-alpine"
+          tag: "$TARGET_BRANCH_NO_SLASHES-$CIRCLE_BRANCH_NO_SLASHES-alpine,$TARGET_REVISION-alpine,$SENSU_VERSION-$BUILD_NUMBER-alpine"
           pre-steps:
             - checkout
             - docker-login
@@ -365,7 +365,7 @@ workflows:
           name: build-rhel7
           platforms: linux/amd64
           path: dockerfiles/redhat7
-          tag: "$TARGET_BRANCH_NO_SLASHES-$CIRCLE_BRANCH_NO_SLASHES-rhel7,$TARGET_REVISION-rhel7"
+          tag: "$TARGET_BRANCH_NO_SLASHES-$CIRCLE_BRANCH_NO_SLASHES-rhel7,$TARGET_REVISION-rhel7,$SENSU_VERSION-$BUILD_NUMBER-rhel7"
           pre-steps:
             - checkout
             - docker-login


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

Adds two new tags:
* `$SENSU_VERSION-$BUILD_NUM-alpine`
* `$SENSU_VERSION-$BUILD_NUM-rhel7`

This will eliminate the need to find the git revision when we know which version & build number we want to promote to another repository.